### PR TITLE
Add min-height to ace_editor class

### DIFF
--- a/programming.css
+++ b/programming.css
@@ -1,6 +1,7 @@
 .ace_editor {
     width: 100%; 
     min-width: 30em;
+    min-height: 2.5em;
     height: auto; 
     border: 1px solid #ccc;
     margin: 0.5em 0;


### PR DESCRIPTION
Ensure that there is at least one line visible in the Ace editor. Appears to solve an issue with the Numbas lockdown browser, where occasionally the editor has no height at all.